### PR TITLE
Fix happo config

### DIFF
--- a/.happo.cjs
+++ b/.happo.cjs
@@ -1,8 +1,6 @@
 const { RemoteBrowserTarget } = require('happo.io')
 const happoPluginStorybook = require('happo-plugin-storybook')
 
-require('dotenv').config()
-
 module.exports = {
   apiKey: process.env.HAPPO_API_KEY,
   apiSecret: process.env.HAPPO_API_SECRET,


### PR DESCRIPTION
Removes the unneeded dotenv line from the happo config so it doesn't attempt to import dotenv that currently doesn't exist in our dependency tree.